### PR TITLE
allow uppercase urls

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1066,7 +1066,7 @@ class QuestionsController < ApplicationController
   # POST /questions
   # POST /questions.xml
   def create
-    @question = Question.new(params[:question].slice(:name, :ideas, :url))
+    @question = Question.new(params[:question].slice(:name, :ideas, :url, :information))
     @user = User.new(:email => params[:question]['email'],
                      :password => params[:question]['password'],
                      :password_confirmation => params[:question]['password']) unless signed_in?

--- a/app/models/earl.rb
+++ b/app/models/earl.rb
@@ -2,6 +2,9 @@ class Earl < ActiveRecord::Base
   @@reserved_names = ["questions", "question", 'about', 'privacy', 'tour', 'no_google_tracking', 'admin', 'abingo', 'earls', 'signup', 'sign_in', 'sign_out','clicks', 'fakequestion', 'photocracy', 'fotocracy']
   validates_presence_of :question_id, :on => :create, :message => "can't be blank"
   validates_presence_of :name, :on => :create, :message => "can't be blank"
+  validates_exclusion_of :name, :in => @@reserved_names, :message => "'%{value}' is reserved"
+  validates_format_of :name, :on => :create, :with => /\A[a-zA-Z0-9\.\-\_]+\z/, :message => "allows only 'A-Za-z0-9.-_' characters"
+  validates_uniqueness_of :name, :case_sensitive => false
   validates_length_of :welcome_message, :maximum=>350, :allow_nil => true, :allow_blank => true
   has_friendly_id :name, :use_slug => true, :reserved => @@reserved_names 
   has_attached_file :logo, :whiny_thumbnails => true, :styles => { :banner => "450x47>", :medium => "150x150>" }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -29,7 +29,7 @@ class Question < ActiveResource::Base
     Earl.find_by_question_id(id).name
   end
  
-  %w(name url the_name ideas).each do |attr|
+  %w(name url the_name ideas information).each do |attr|
     define_method attr do
       attributes[attr]
     end

--- a/features/idea_marketplaces/create_question.feature
+++ b/features/idea_marketplaces/create_question.feature
@@ -3,6 +3,14 @@ Feature: Creating Idea marketplaces
 	As a question admin
 	I want to be able to create an idea marketplace
 
+  Scenario Outline: invalid submission should retain information field
+    Given I am on the question create page
+    When I fill in all fields with valid data except "question_url"
+    And I fill in "question_information" with "ruAbudtav8"
+    And I press "Create"
+    Then I should see "ruAbudtav8"
+    And I should be on the questions index page
+
 	Scenario Outline: user submits question registration info
 		Given I am on the question create page
 		When I fill in all fields with valid data except "<field>"
@@ -18,7 +26,7 @@ Feature: Creating Idea marketplaces
 	   |question_url|"testing_45-6"   |Congratulations. You are about to discover some great ideas.| the Cast Votes page for 'testing_45-6'|
 	
          Scenarios: invalid registration info
-	   |field       |value    |resulttext                     | landing_page|
+	   |field       |value      |resulttext     | landing_page           |
 	   |question_url|"bad url"  |Url allows only|the questions index page|
 	   |question_url|"bad@url"  |Url allows only|the questions index page|
 	   |question_url|"bad@url"  |Url allows only|the questions index page|

--- a/features/idea_marketplaces/create_question.feature
+++ b/features/idea_marketplaces/create_question.feature
@@ -19,20 +19,20 @@ Feature: Creating Idea marketplaces
 	
          Scenarios: invalid registration info
 	   |field       |value    |resulttext                     | landing_page|
-	   |question_url|"bad url"  |Url contains spaces|the questions index page|
-	   |question_url|"bad@url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad@url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad/url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad:url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad=url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad+url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad'url"  |Url contains special characters|the questions index page|
-	   |question_url|"bad$url"  |Url contains special characters|the questions index page|
-	   |question_url|" badurl"  |Url contains special characters|the questions index page|
-	   |question_url|"badurl "  |Url contains special characters|the questions index page|
-	   |question_url|"questions"|Url has already been taken|the questions index page|
-	   |question_url|"admin"    |Url has already been taken|the questions index page|
-	   |question_url|"admin"    |Url has already been taken|the questions index page|
+	   |question_url|"bad url"  |Url allows only|the questions index page|
+	   |question_url|"bad@url"  |Url allows only|the questions index page|
+	   |question_url|"bad@url"  |Url allows only|the questions index page|
+	   |question_url|"bad/url"  |Url allows only|the questions index page|
+	   |question_url|"bad:url"  |Url allows only|the questions index page|
+	   |question_url|"bad=url"  |Url allows only|the questions index page|
+	   |question_url|"bad+url"  |Url allows only|the questions index page|
+	   |question_url|"bad'url"  |Url allows only|the questions index page|
+	   |question_url|"bad$url"  |Url allows only|the questions index page|
+	   |question_url|" badurl"  |Url allows only|the questions index page|
+	   |question_url|"badurl "  |Url allows only|the questions index page|
+	   |question_url|"questions"|is reserved|the questions index page|
+	   |question_url|"admin"    |is reserved|the questions index page|
+	   |question_url|"admin"    |is reserved|the questions index page|
 
 	Scenario: User submits an existing url
 		Given an idea marketplace exists with url 'taken'
@@ -57,7 +57,7 @@ Feature: Creating Idea marketplaces
 		Scenarios: missing fields
 			|field|result_text|
 			|question_name|Name is blank|
-			|question_url|Url is blank|
+			|question_url|Url can't be blank|
 			|question_ideas|Ideas are blank|
 			|question_email|Email can't be blank|
 			|question_password|Password can't be blank|

--- a/features/results/view_results.feature
+++ b/features/results/view_results.feature
@@ -27,14 +27,12 @@ Feature: View Results
 		   |locale|fr|
 
   Scenario: A user should not be allowed to see the view results page if hidden
-     Given an idea marketplace quickly exists with url 'test'
-     And idea marketplace 'test' has results hidden
+     Given idea marketplace 'test' has results hidden
      Given I am on the View Results page for 'test'
      Then I should see "The results from this wiki survey are only visible to the person who created it."
 
   Scenario: An admin should be allowed to see the view results page if hidden
-     Given an idea marketplace quickly exists with url 'test'
-     And idea marketplace 'test' has results hidden
+     Given idea marketplace 'test' has results hidden
      And I sign in as the admin for 'test'
      Given I am on the View Results page for 'test'
      Then I should not see "The results from this wiki survey are only visible to the person who created it."

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -75,6 +75,20 @@ describe QuestionsController do
         response.should redirect_to(earl_url('urlname', :just_created => true))
       end
 
+      it "allows upper case letters" do
+        sign_in_as Factory.create :admin_confirmed_user
+        Question.stub!(:new).with({"name" => 'this name', "url" => 'UrlName'}).and_return(mock_question(:save => true, :valid? => true, :attributes => {}, :fq_earl => '/'))
+        post :create, :question => {:name => 'this name', :url => 'UrlName'}
+        response.should redirect_to(earl_url('UrlName', :just_created => true))
+      end
+
+      it "redirects to the created question" do
+        sign_in_as Factory.create :admin_confirmed_user
+        Question.stub!(:new).with({"name" => 'this name', "url" => 'urlname'}).and_return(mock_question(:save => true, :valid? => true, :attributes => {}, :fq_earl => '/'))
+        post :create, :question => {:name => 'this name', :url => 'urlname'}
+        response.should redirect_to(earl_url('urlname', :just_created => true))
+      end
+
       it "redirects to the verify page if suspicious ideas" do
         sign_in_as Factory.create :admin_confirmed_user
         Question.stub!(:new).with({"name" => 'this name', "url" => 'newurlname', "ideas" => "http://example.com\nwhat\nnow"}).and_return(mock_question(:save => true, :valid? => true, :attributes => {}, :fq_earl => '/'))

--- a/test/unit/earl_test.rb
+++ b/test/unit/earl_test.rb
@@ -10,8 +10,13 @@ class EarlTest < ActiveSupport::TestCase
     assert_valid Factory.create(:earl)
   end
 
-  should "not allow reserved words to be saved" do 
-	  assert_raises(FriendlyId::SlugGenerationError) { Factory.create(:earl, :name => "privacy")}
+  should_allow_values_for :name, "UPPERCASE", "testing", "test12-_."
+  should_not_allow_values_for :name, Earl.reserved_names.first, Earl.reserved_names.last, "test12-_,.", "with space", "", "bals@bla", "test/this", "askdf|", "=sdkjfs", '+'
+
+  should "validate uniqueness of name case insensitive" do
+    e = Factory.create(:earl)
+    assert_bad_value(Earl, :name, e.name.upcase)
+    assert_bad_value(Earl, :name, e.name)
   end
 
   should "show nil ideas as not spammy" do

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
-#class QuestionTest < ActiveSupport::TestCase
+class QuestionTest < ActiveSupport::TestCase
+  should "pass along earl validation errors" do
+    invalid_urls = [Earl.reserved_names.first, Earl.reserved_names.last, "test12-_,.", "with space", "", "bals@bla", "test/this", "askdf|", "=sdkjfs", '+']
+    invalid_urls.each do |url|
+      q = Question.new(:name => 'What question?', :ideas => "one\ntwo\nthree\nfour", :url => url)
+      assert_equal false, q.valid?
+    end
+  end
+
+  should "allow upper case" do
+    q = Question.new(:name => 'What question?', :ideas => "one\ntwo\nthree\nfour", :url => "UPIOWNR")
+    assert q.valid?
+  end
+
+end
 #
 # # in order to make this work, the test server has to be running:
 #	# export RAILS_ENV=test && ./script/server 4000
@@ -100,6 +114,3 @@ require 'test_helper'
 #    end
 #
 #  end
-#
-#end
-

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
+
   should "pass along earl validation errors" do
     invalid_urls = [Earl.reserved_names.first, Earl.reserved_names.last, "test12-_,.", "with space", "", "bals@bla", "test/this", "askdf|", "=sdkjfs", '+']
     invalid_urls.each do |url|
@@ -12,6 +13,11 @@ class QuestionTest < ActiveSupport::TestCase
   should "allow upper case" do
     q = Question.new(:name => 'What question?', :ideas => "one\ntwo\nthree\nfour", :url => "UPIOWNR")
     assert q.valid?
+  end
+
+  should "make information attribute accessible" do
+    q = Question.new(:information => "blah")
+    assert_equal "blah", q.information
   end
 
 end


### PR DESCRIPTION
Allows upper case URLs and moves URL validation to Earl model.

Fixes #38 and #37 