### PR TITLE
rescue possible ArgumentError

### DIFF
--- a/app/models/earl.rb
+++ b/app/models/earl.rb
@@ -140,8 +140,13 @@ class Earl < ActiveRecord::Base
 
         display_text = []
         display_fields.each do|key|
-          if session.loc_info[key] && !(/^[0-9]+$/ =~ session.loc_info[key])
-            display_text << session.loc_info[key] 
+          if session.loc_info[key]
+            begin
+              if !(/^[0-9]+$/ =~ session.loc_info[key])
+                display_text << session.loc_info[key]
+              end
+            rescue ArgumentError
+            end
           end
         end
 


### PR DESCRIPTION
We were getting occasional errors with voter_map due to invalid utf8
characters. "ArgumentError: invalid byte sequence in UTF-8"