### PR TITLE
Show all combinations

### DIFF
--- a/app/controllers/earls_controller.rb
+++ b/app/controllers/earls_controller.rb
@@ -37,6 +37,7 @@ class EarlsController < ApplicationController
 		     :with_visitor_stats => true,
 		     :visitor_identifier => @survey_session.session_id}
 
+      show_params.merge!(:algorithm => @earl.prompt_algorithm) unless @earl.prompt_algorithm.blank?
       show_params.merge!({:future_prompts => {:number => 1}, :with_average_votes => true}) if @photocracy
 
       @question = Question.find(@earl.question_id, :params => show_params)

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -210,6 +210,7 @@ class PromptsController < ApplicationController
                             :with_visitor_stats => true,
                             :visitor_identifier => @survey_session.session_id
                           }
+    next_prompt_params.merge!(:algorithm => @earl.prompt_algorithm) unless @earl.prompt_algorithm.blank?
     next_prompt_params.merge!(:future_prompts => {:number => 1}) if @photocracy
     next_prompt_params
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1135,7 +1135,9 @@ class QuestionsController < ApplicationController
 
     respond_to do |format|
       old_lang = @earl.default_lang
-      if @earl.update_attributes(params[:earl].slice(:pass, :logo, :welcome_message, :default_lang, :flag_enabled, :ga_code, :question_should_autoactivate_ideas, :hide_results, :active, :show_cant_decide, :show_add_new_idea))
+      allowed_attributes = [:pass, :logo, :welcome_message, :default_lang, :flag_enabled, :ga_code, :question_should_autoactivate_ideas, :hide_results, :active, :show_cant_decide, :show_add_new_idea]
+      allowed_attributes << :prompt_algorithm if current_user.admin?
+      if @earl.update_attributes(params[:earl].slice(*allowed_attributes))
         flash[:notice] = 'Question settings saved successfully!'
         # redirect to new lang if lang was changed
         if old_lang != @earl.default_lang

--- a/app/views/questions/admin.html.haml
+++ b/app/views/questions/admin.html.haml
@@ -71,6 +71,13 @@
               .controls
                 = # Have English be the first, but sort the rest
                 = f.select :default_lang, [["English", "en"]] + [["French", "fr"], ["Spanish", "es"], ["Portuguese", "pt"], ["Arabic", "ar"], ["Turkish", "tr"], ["Italian", "it"], ["Dutch", "nl"], ["Hebrew", "he"], ["German", "de"], ["Farsi", "fa"], ["Finnish", "fi"], ["Albanian", "sq"], ["Chinese", "zh"], ["Norwegian", "no"], ["Danish", "da"], ["Czech", "cs"], ["Japanese", "ja"], ["Indonesian", "id"]].sort
+
+            - if current_user.admin?
+              .control-group
+                = f.label :prompt_algorithm, "Prompt Algorithm" , :class => 'control-label'
+                .controls
+                  = f.select :prompt_algorithm, [['No preference', nil], ["Catchup", "catchup"], ["All combos", "all-combos"]]
+
             .control-group
               = f.label :ga_code, t('admin.google_analytics_code') + ' ' + link_to('<i class="glyphicon glyphicon-question-sign"></i>', 'http://blog.allourideas.org/post/947544304/add-google-analytics-on-your-idea-marketplace', :target=> '_blank'), :class => 'control-label'
               .controls

--- a/db/migrate/20180615182055_add_prompt_algorithm_to_earl.rb
+++ b/db/migrate/20180615182055_add_prompt_algorithm_to_earl.rb
@@ -1,0 +1,9 @@
+class AddPromptAlgorithmToEarl < ActiveRecord::Migration
+  def self.up
+    add_column :earls, :prompt_algorithm, :string
+  end
+
+  def self.down
+    remove_column :earls, :prompt_algorithm
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161202144215) do
+ActiveRecord::Schema.define(:version => 20180615182055) do
 
   create_table "alternatives", :force => true do |t|
     t.integer "experiment_id"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(:version => 20161202144215) do
     t.string   "verify_code"
     t.boolean  "show_cant_decide",                 :default => true
     t.boolean  "show_add_new_idea",                :default => true
+    t.string   "prompt_algorithm"
   end
 
   add_index "earls", ["question_id"], :name => "index_earls_on_question_id"


### PR DESCRIPTION
Related: https://github.com/allourideas/pairwise-api/pull/43

This pull request adds the ability for admins (not wiki survey creators) to select which prompt selection algorithm to use. I figured you weren't keen on having wiki survey creators modify which prompt selection to use, so I limited it to only admins. The default is no prompt selection algorithm is sent to pairwise and pairwise decides which algorithm to use. Prompt selection algorithm options include "Catchup" and "All combos".

@msalganik does this look good to you?