### PR TITLE
Fix race condition with clicks on new idea

### DIFF
--- a/app/views/earls/_vote_box_js.html.erb
+++ b/app/views/earls/_vote_box_js.html.erb
@@ -98,7 +98,7 @@
       var newRight = newRightDiv.find('.btn-vote-idea');
       var bothNew = newLeft.add(newRight);
 
-      bothNew.addClass('btn-primary').removeClass('btn-success').removeClass('disabled');
+      bothNew.addClass('btn-primary').removeClass('btn-success');
 
       newLeft.html(data.newleft);
       newRight.html(data.newright);
@@ -119,7 +119,9 @@
       $('#right_side_text').val(data.newright);
 
       // animation for sliding in / out choices
-      newLeftDiv.add(newRightDiv).slideDown();
+      newLeftDiv.add(newRightDiv).slideDown(function() {
+        bothNew.removeClass('disabled');
+      });
       oldLeftDiv.add(oldRightDiv).slideUp(function() {
         $(this).remove();
       });


### PR DESCRIPTION
Clicks on a new idea as it is sliding in will cause both old and new
ideas to collapse, causing no ideas to be visible. Instead, we'll only
remove the disabled class on the new ideas after they've fully appeared.