### PR TITLE
Redact user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,5 +21,12 @@ class User < ActiveRecord::Base
   def admin?
       self.admin
   end
-  
+
+  def redact!
+    self.email = "#{SecureRandom.hex}.redacted@host.allourideas"
+    newpass = SecureRandom.hex
+    self.update_password(newpass, newpass)
+    self.save!
+  end
+
 end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -48,6 +48,22 @@ namespace :database do
   task :redact_survey, [:name] => [:environment] do |t, args|
     earl = Earl.find_by_name(args[:name])
     earl.redact!
-    puts "Redacted #{earl.name}"
+    puts "Redacted survey: #{earl.name}"
+  end
+
+  desc "Redact a user by email"
+  task :redact_user, [:email] => [:environment] do |t, args|
+    question_ids = []
+    user = User.find_by_email(args[:email])
+    raise "User not found by email address: #{args[:email]}" unless user
+    user.redact!
+    user.earls.each do |earl|
+      earl.redact!
+      question_ids << earl.question_id
+      puts "Redacted survey: #{earl.name}"
+    end
+
+    puts "Redacted user: #{args[:email]}"
+    puts "User's question_ids: #{question_ids.join(", ")}" if question_ids.length > 0
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -18,6 +18,14 @@ class UserTest < ActiveSupport::TestCase
 	  assert user.email_confirmed
   end
 
+  should "support redaction" do
+    user = Factory.create(:user)
+    old_pass = user.encrypted_password
+    user.redact!
+    assert user.email.end_with?(".redacted@host.allourideas")
+    assert_not_equal old_pass, user.encrypted_password
+  end
+
   should "determine ownership of Earls correctly" do
 	  owner = Factory.create(:user)
 	  non_owner = Factory.create(:user)


### PR DESCRIPTION
Expansion of work in https://github.com/allourideas/pairwise-api/pull/46

Users can now be redacted, which will redact their email address and reset their password. If the rake task is used, the user will be redacted and all their surveys will be redacted as well.