### PR TITLE
widget: remove note to allow third-party cookies

### DIFF
--- a/app/views/widget/earls/_cast_votes.html.haml
+++ b/app/views/widget/earls/_cast_votes.html.haml
@@ -7,10 +7,7 @@
       = link_to("Cookies are required", 'http://blog.allourideas.org/post/54515392435/cookies', :target => '_blank')
       for voting, and it looks like third-party cookies may be disabled in your browser.
       In order to vote, you may
-      = link_to("vote on the main site", @cast_votes_url, :target => '_blank')
-      or allow
-      = link_to("third-party cookies", 'http://en.wikipedia.org/wiki/Third-party_cookie#Privacy_and_third-party_cookies', :target => '_blank')
-      in your browser.
+      = link_to("vote on the main site.", @cast_votes_url, :target => '_blank')
 #voting-container.scrollbar_container
   .question_container
     %table.question.center.no_padding


### PR DESCRIPTION
As discussed in #76, we don't want to suggest to users that they should allow third-party cookies in their browser anymore. This is no longer the default in Safari and changing that setting will reduce the user's privacy as they use the internet.

